### PR TITLE
Fixed composer.json for kimai version 2.31.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "gbs-it/zip-projectrenderer-plugin",
     "description": "A Kimai 2 plugin that allows to create a separate PDF file per project for several selected projects in the export. The PDF-Files which are then packed into a zip archive that is downloaded.",
-    "homepage": ""https://www.kimai.org/store/",
+    "homepage": "https://www.kimai.org/store/",
     "type": "kimai-plugin",
     "version": "0.8",
 	"keywords": [

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "extra": {
         "kimai": {
-            "require": "1.6",
+            "require": 16000,
 			"version": "0.8",
             "name": "ZipProjectRendererBundle"
         }


### PR DESCRIPTION
Installed this plugin on my instance and it broke the entire project

See below,
<img width="677" alt="Screenshot 2025-04-27 at 10 14 59 AM" src="https://github.com/user-attachments/assets/b320a71a-4243-4fb7-aea2-ef33fae0cb4e" />

tried to reload from inside the container using,
`bin/console kimai:reload
`
it printed following error,
<img width="539" alt="Screenshot 2025-04-27 at 10 15 11 AM" src="https://github.com/user-attachments/assets/788440fc-bdca-4982-9e2f-46f7e0622d9f" />

fixed the issue in JSON file


then got another issue,

<img width="1097" alt="Screenshot 2025-04-27 at 10 23 39 AM" src="https://github.com/user-attachments/assets/35098591-a139-4574-bdc1-e6dd4ca1bc77" />

fixed it by chainging extra.kimai.require from,
<img width="406" alt="Screenshot 2025-04-27 at 10 37 38 AM" src="https://github.com/user-attachments/assets/c69fdc7a-31bc-4a54-9748-e107466c25a9" />


to,
<img width="536" alt="Screenshot 2025-04-27 at 10 36 33 AM" src="https://github.com/user-attachments/assets/79090d57-8422-465c-afcd-71cc1b2998c8" />

